### PR TITLE
Remove combustion ui and fix plex request/limits on CPU

### DIFF
--- a/charts/seedbox/values.yaml
+++ b/charts/seedbox/values.yaml
@@ -51,8 +51,8 @@ transmission:
     value: "1000"
   - name: PUID
     value: "1000"
-  - name: TRANSMISSION_WEB_HOME
-    value: "/combustion-release/"
+#  - name: TRANSMISSION_WEB_HOME
+#    value: "/combustion-release/"
   - name: TZ
     value: "America/New_York"
   ingress:

--- a/helmfile.d/21-plex.yaml
+++ b/helmfile.d/21-plex.yaml
@@ -37,10 +37,7 @@ releases:
             claimName: yasr-volume
             subPath: "configs/plex"
       - resources:
-          limits:
-            cpu: 4000m
-            memory: 2Gi
           requests:
-            cpu: 4000m
+            cpu: 2000m
             memory: 2Gi
       - values/plex-pictures.yaml


### PR DESCRIPTION
Removed combustion ui from transmission it doesnt have trash and remove feature which I used a lot

And removed the limit on plex's container and lowered its request of CPU to 2000 as it was using too much. I have to limit the other apps to help plex.

Signed-off-by: Carlos Ravelo <ravelo.carlos@gmail.com>